### PR TITLE
feat: draft on hold standard, update spec, add references

### DIFF
--- a/docs/spec/code_system/on_hold_process.md
+++ b/docs/spec/code_system/on_hold_process.md
@@ -17,8 +17,16 @@ This Code System is used or referenced by:
 
 ## Definition
 
-Represents the reason a [Record](/docs/spec/element/message/record) is paused, preventing it
-from being actioned on. It is intended to be excluded from processing time.
+The purpose of the On Hold data element is to track periods during which an application is paused due to circumstances
+that prevent a [Record](/docs/spec/element/message/record) from being actioned.
+
+## Standard Reference
+
+This specification implements the following:
+
+- [`<On Hold>` Standard](/docs/standard/element/process_tracking/onhold)
+
+In the event of conflict, the Standard definition is authoritative.
 
 ## Content
 
@@ -28,11 +36,11 @@ Not Applicable
 
 ### Concepts
 
-| Code                        | Display                   | Description                                                                                                      |
-| --------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `CLIENT_REQUEST`            | Client Request            | The client requests the application be paused for a valid reason supported by staff.                             |
-| `LEGAL_ACTION`              | Legal Action              | Legal proceedings or advice from legal counsel require the application to be paused.                             |
-| `MISSING_INFORMATION`       | Missing Information       | Application requirements are not met during the review and additional information is required from the proponent |
-| `PENDING_EXTERNAL_DECISION` | Pending External Decision | Awaiting input or decisions from other agencies or processes that affect the application.                        |
+| Code                        | Display                   | Description                                                                                              |
+| --------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `APPLICANT_REQUEST`         | Applicant Request         | The application is paused as requested by applicant and supported by staff.                              |
+| `LEGAL_ACTION`              | Legal Action              | The application is subject to legal proceedings, or legal counsel has advised that processing be paused. |
+| `MISSING_INFORMATION`       | Missing Information       | More information is required from the applicant to proceed with the review.                              |
+| `PENDING_EXTERNAL_DECISION` | Pending External Decision | The application requires decision, approval, or input from another agency or an external process.        |
 
 ## Errata

--- a/docs/spec/code_system/on_hold_process.md
+++ b/docs/spec/code_system/on_hold_process.md
@@ -24,7 +24,7 @@ that prevent a [Record](/docs/spec/element/message/record) from being actioned.
 
 This specification implements the following:
 
-- [`<On Hold>` Standard](/docs/standard/element/process_tracking/onhold)
+- [`<On Hold>` Standard](/docs/standard/element/process_tracking/on-hold)
 
 In the event of conflict, the Standard definition is authoritative.
 

--- a/docs/spec/code_system/on_hold_process.md
+++ b/docs/spec/code_system/on_hold_process.md
@@ -24,9 +24,7 @@ that prevent a [Record](/docs/spec/element/message/record) from being actioned.
 
 This specification implements the following:
 
-- [`<On Hold>` Standard](/docs/standard/element/process_tracking/on-hold)
-
-In the event of conflict, the Standard definition is authoritative.
+- [On Hold](/docs/standard/element/process_tracking/on_hold) Standard
 
 ## Content
 

--- a/docs/standard/element/process_tracking/on_hold.md
+++ b/docs/standard/element/process_tracking/on_hold.md
@@ -1,5 +1,5 @@
 ---
-id: on-hold
+id: on_hold
 title: On hold 📝
 description: On hold process event tracking
 tags:
@@ -9,7 +9,7 @@ tags:
 
 [![Maturity:Trial](https://img.shields.io/badge/Maturity-Draft-yellow)](/docs/standard#maturity)
 
-Official URL: `https://bcgov.github.io/nr-pies/docs/standard/element/process_tracking/onhold`
+Official URL: `https://bcgov.github.io/nr-pies/docs/standard/element/process_tracking/on_hold`
 
 ## Purpose
 
@@ -29,7 +29,7 @@ This element is used to:
 
 The On Hold element can apply to both application and post-issuance phases of an authorization and may be used multiple
 times throughout the lifecycle of an authorization. Each On Hold record must include a start date and end date when no
-longer on hold, a reason,and the user who initiated the hold.
+longer on hold, a reason, and the user who initiated the hold.
 
 ## Guidance
 
@@ -40,11 +40,12 @@ longer on hold, a reason,and the user who initiated the hold.
 
 ## Properties
 
-- **Data format**: string
-- **Null**: Cannot be `null` – every authorization must have a reason
-- **Relationships:**
-  - See [Milestone](/docs/standard/element/process_tracking/milestone) Dates: On hold start and end dates.
-- **Change control:** an authorization may be put on hold multiple times through it's phases.
+| Property       | Definition                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| Type           | `string`                                                                                   |
+| Mandatory      | Yes                                                                                        |
+| Relationships  | [Milestone](/docs/standard/element/process_tracking/milestone) On hold start and end dates |
+| Change Control | May be put on hold multiple times                                                          |
 
 ## Application level
 
@@ -63,9 +64,6 @@ longer on hold, a reason,and the user who initiated the hold.
 
 This element is utilized in the technical implementation:
 
-- See: [`<On Hold Process>` Specification](/docs/spec/code_system/on_hold_process)
-
-The specification defines format, structure, and validation rules,
-but does not alter the meaning or intent of this element.
+- See: [On Hold Process](/docs/spec/code_system/on_hold_process) Specification
 
 ## References

--- a/docs/standard/element/process_tracking/onhold.md
+++ b/docs/standard/element/process_tracking/onhold.md
@@ -28,15 +28,15 @@ This element is used to:
 - Provide context for analysis and metrics.
 
 The On Hold element can apply to both application and post-issuance phases of an authorization and may be used multiple
-times throughout the lifecycle of an authorization. Each On Hold record must include a start and end date, a reason,
-and the user who initiated the hold.
+times throughout the lifecycle of an authorization. Each On Hold record must include a start date and end date when no
+longer on hold, a reason,and the user who initiated the hold.
 
 ## Guidance
 
 - On Hold periods must be time-stamped
 - Only one active On Hold record may exist at a time.
-- Applications must be manually taken Off Hold to resume processing.
-- O Hold may be referred to as “Parked” in some systems; the effect is the same
+- On Hold applications must be manually taken Off Hold by setting and end date to resume processing.
+- On Hold may be referred to as “Parked” in some systems; the effect is the same
 
 ## Properties
 

--- a/docs/standard/element/process_tracking/onhold.md
+++ b/docs/standard/element/process_tracking/onhold.md
@@ -1,37 +1,71 @@
 ---
 id: on-hold
-title: On hold 🚧
+title: On hold 📝
 description: On hold process event tracking
 tags:
   - business
   - executive
 ---
 
-[![Maturity:Draft](https://img.shields.io/badge/Maturity-Planning-orange)](/docs/standard#maturity)
+[![Maturity:Trial](https://img.shields.io/badge/Maturity-Draft-yellow)](/docs/standard#maturity)
 
 Official URL: `https://bcgov.github.io/nr-pies/docs/standard/element/process_tracking/onhold`
 
 ## Purpose
 
-To track delays in handling applications, allowing for identification of broader issues rather than individual staff performance.
-Accurate tracking helps improve processes and reduce backlog.
-
-- Dates for when on hold have been included in the list of milestone dates.
+The purpose of the On Hold data element is to track periods during which an application is paused due to circumstances
+that prevent it from being actioned. This ensures that turnaround time metrics reflect only the time when the application
+is actively being processed. Accurate tracking of On Hold periods supports transparency, performance measurement, and
+process improvement across permitting systems.
 
 ## Usage
 
-This level offers a high level ability to enable reporting if an application or issued authorization is active or not
-and the ability to determine if the application has not yet started to be worked on by the intake or authorizing agency.
-Time ranges or events define the start and end of stages within the process.
+This element is used to:
+
+- Exclude time spent on hold from official processing time calculations.
+- Identify systemic delays and opportunities for process improvement.
+- Support consistent reporting across business areas and systems.
+- Provide context for analysis and metrics.
+
+The On Hold element can apply to both application and post-issuance phases of an authorization and may be used multiple
+times throughout the lifecycle of an authorization. Each On Hold record must include a start and end date, a reason,
+and the user who initiated the hold.
 
 ## Guidance
 
-## Structure
+- On Hold periods must be time-stamped
+- Only one active On Hold record may exist at a time.
+- Applications must be manually taken Off Hold to resume processing.
+- O Hold may be referred to as “Parked” in some systems; the effect is the same
+
+## Properties
+
+- **Data format**: string
+- **Null**: Cannot be `null` – every authorization must have a reason
+- **Relationships:**
+  - See [Milestone](/docs/standard/element/process_tracking/milestone) Dates: On hold start and end dates.
+- **Change control:** an authorization may be put on hold multiple times through it's phases.
 
 ## Application level
 
+[![Maturity:Draft](https://img.shields.io/badge/Maturity-Draft-yellow)](/docs/standard#maturity)
+
+| Display                   | Description                                                                                              |
+| ------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Applicant Request         | The application is paused as requested by applicant and supported by staff.                              |
+| Legal Action              | The application is subject to legal proceedings, or legal counsel has advised that processing be paused. |
+| Missing Information       | More information is required from the applicant to proceed with the review.                              |
+| Pending External Decision | The application requires decision, approval, or input from another agency or an external process.        |
+
 ## Post issuance level
 
-## Specification
+## Relationship to Specification
+
+This element is utilized in the technical implementation:
+
+- See: [`<On Hold Process>` Specification](/docs/spec/code_system/on_hold_process)
+
+The specification defines format, structure, and validation rules,
+but does not alter the meaning or intent of this element.
 
 ## References

--- a/docs/standard/element/process_tracking/state.md
+++ b/docs/standard/element/process_tracking/state.md
@@ -29,7 +29,7 @@ States may be concurrent when parallel activities are valid.
 
 - States do not carry timing; dates and durations come from Milestones.
 
-- If On hold is used, capture a reason, see [On hold](/docs/standard/element/process_tracking/on-hold) for reasons.
+- If On hold is used, capture a reason, see [On hold](/docs/standard/element/process_tracking/on_hold) for reasons.
 
 ## Properties
 
@@ -69,7 +69,7 @@ States may be concurrent when parallel activities are valid.
 | Review completed           | Review completion and/or recommendations | The application has been reviewed/recommendation and comment. prepared.                                                                                                             |
 | Rejected                   | Rejected                                 | The application has been rejected by deciding. authority                                                                                                                            |
 | Withdrawn                  | Withdrawn                                | The application has been withdrawn by applicant. This may occur at any stage prior to a final decision or issuance.                                                                 |
-| On hold                    | On hold ''with reason''                  | The application has been put on hold for a defined set of reasons. See [On hold](/docs/standard/element/process_tracking/on-hold) section.                                          |
+| On hold                    | On hold ''with reason''                  | The application has been put on hold for a defined set of reasons. See [On hold](/docs/standard/element/process_tracking/on_hold) section.                                          |
 
 ## Post issuance level
 


### PR DESCRIPTION
This PR includes the agreed upon draft On Hold Reasons for the standard and updates the spec side to align the terms and definitions. It is also the first attempt to standardize the links between the two areas.

# Description

Standard: 
* Added: Purpose, Usage, Guidance, table of the terms and definitions
* Added: Relationship to the Specification link and wording

Spec: 
* Updated: All Definition
* Changed: Client Requested to Applicant Requested
* Added: Relationship to the Standard section with link and text

 ## Related Issues/Tickets

"Closes PMT-1067 or "Pre-cursor to PSB-148"

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [X] Documentation update

## Checklist

<!-- Please check all that apply: -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have checked that the site is buildable with my changes
- [x] I have cross-referenced between the standards and specifications for consistency
- [x] I have ensured there are no visible errors in the JSON schema (if edited)
- [x] I have added necessary documentation (if appropriate)

## Additional Notes

<!-- Add any extra context, screenshots, or discussion points here. -->
